### PR TITLE
Fix cert ownership on upgrade

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -580,6 +580,12 @@ if [ "$1" = 1 ]; then
     ln -s /run/cockpit/motd /etc/motd.d/cockpit
     ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
 fi
+# switch old self-signed cert group from cockpit-wsintance to cockpit-ws on upgrade
+if [ "$1" = 2 ]; then
+    certfile=/etc/cockpit/ws-certs.d/0-self-signed.cert
+    test -f $certfile && stat -c '%G' $certfile | grep -q cockpit-wsinstance && chgrp cockpit-ws $certfile
+fi
+
 %if 0%{?suse_version}
 %set_permissions %{_libexecdir}/cockpit-session
 %endif


### PR DESCRIPTION
The self-signed cert ownership has been changed from cockpit-wsinstance
to cockpit-ws. If old one exists, upgraded cockpit will fail to start.