### PR TITLE
Also require SUSE branding files at runtime

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -463,6 +463,8 @@ Requires(postun): systemd
 %else
 Requires: group(wheel)
 Requires(pre): permissions
+Requires: distribution-logos
+Requires: wallpaper-branding
 %endif
 
 %description ws


### PR DESCRIPTION
With branding packages only in BuildRequires, the links created in
brandings might become stale after installation on target system.