### PR TITLE
[251.3] Also require SUSE branding files at runtime

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -494,6 +494,8 @@ Recommends: system-logos
 Suggests: sssd-dbus
 %if 0%{?suse_version}
 Requires(pre): permissions
+Requires: distribution-logos
+Requires: wallpaper-branding
 %endif
 
 %description ws


### PR DESCRIPTION
With branding packages only in BuildRequires, the links created in
brandings might become stale after installation on target system.

(cherry picked from commit fbf45550895d5aa2a3c8bf1589b54ff0704b487f)