### PR TITLE
Add SLE Micro specific patches to spec (bsc#1197224)

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -65,6 +65,9 @@ Source97:       node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Patch0:         cockpit-redhatfont.diff
 Patch1:         0001-selinux-allow-login-to-read-motd-file.patch
+# SLE Micro specific patches
+Patch100:       remove-pwscore.patch
+Patch101:       hide-pcp.patch
 
 # in RHEL 8 the source package is duplicated: cockpit (building basic packages like cockpit-{bridge,system})
 # and cockpit-appstream (building optional packages like cockpit-{pcp})
@@ -171,7 +174,14 @@ Recommends: subscription-manager-cockpit
 
 %prep
 %setup -q -n cockpit-%{version}
-%autopatch -p1
+%patch0 -p1
+%patch1 -p1
+
+%if 0%{?sle_version}
+%patch100 -p1
+%patch101 -p1
+%endif
+
 cp %SOURCE1 tools/cockpit.pam
 #
 local-npm-registry %{_sourcedir} install --also=dev --legacy-peer-deps
@@ -443,7 +453,9 @@ Requires: cockpit-bridge >= %{version}-%{release}
 Requires: shadow-utils
 %endif
 Requires: grep
+%if !0%{?sle_version}
 Requires: /usr/bin/pwscore
+%endif
 Requires: /usr/bin/date
 Provides: cockpit-shell = %{version}-%{release}
 Provides: cockpit-systemd = %{version}-%{release}


### PR DESCRIPTION
These hide PCP metrics (not available as package in SLE, to be added
back as a container) and pwscore password checking (might be added to
SLE Micro later).

Patches attached: [patches.zip](https://github.com/lnussel/cockpit/files/8304679/patches.zip)